### PR TITLE
[#6] feat: replace useQuery with useGoalQuery and add DEFAULT_STALE_TIME constant

### DIFF
--- a/src/app/seasons/page.tsx
+++ b/src/app/seasons/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useQuery } from '@tanstack/react-query';
+import { useGoalQuery } from '@/hooks/useGoalQuery';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -13,17 +13,14 @@ import {
 import { Badge } from '@/components/ui/badge';
 import { Calendar, ChevronRight, Trophy, Users, ArrowLeft } from 'lucide-react';
 import { getAllSeasons, getSeasonRoute } from '@/features/seasons/api';
+import { DEFAULT_STALE_TIME } from '@/constants/query';
 
 export default function SeasonsPage() {
   const {
     data: seasons = [],
     isLoading: loading,
     error,
-  } = useQuery({
-    queryKey: ['seasons', 'all'],
-    queryFn: getAllSeasons,
-    staleTime: 5 * 60 * 1000, // 5분간 캐시 유지
-  });
+  } = useGoalQuery(getAllSeasons, [], { staleTime: DEFAULT_STALE_TIME });
 
   const getStatusBadge = (status?: string) => {
     switch (status) {

--- a/src/constants/query.ts
+++ b/src/constants/query.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_STALE_TIME = 5 * 60 * 1000; // 5분

--- a/src/features/matches/components/MatchCard/GoalSection.tsx
+++ b/src/features/matches/components/MatchCard/GoalSection.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import React from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useGoalQuery } from '@/hooks/useGoalQuery';
 import { MatchWithTeams } from '@/lib/types/database';
 import { getMatchGoals } from '../../api';
+import { DEFAULT_STALE_TIME } from '@/constants/query';
 
 interface GoalSectionProps {
   match: MatchWithTeams;
@@ -16,10 +17,8 @@ const GoalSection: React.FC<GoalSectionProps> = ({ match, className = '' }) => {
     data: goals = [],
     isLoading,
     error,
-  } = useQuery({
-    queryKey: ['match', 'goals', match.match_id],
-    queryFn: () => getMatchGoals(match.match_id),
-    staleTime: 5 * 60 * 1000, // 5분간 캐시 유지
+  } = useGoalQuery(getMatchGoals, [match.match_id], {
+    staleTime: DEFAULT_STALE_TIME,
   });
 
   // 득점이 없으면 렌더링하지 않음
@@ -95,7 +94,7 @@ const GoalSection: React.FC<GoalSectionProps> = ({ match, className = '' }) => {
               <span className="ml-1 text-gray-500">
                 {goal.goal_time}'{' '}
                 {goal.goal_type === 'penalty'
-                  ? '🎯'
+                  ? '��'
                   : goal.goal_type === 'own_goal'
                     ? '🔄'
                     : '⚽'}

--- a/src/features/matches/components/MatchCard/MatchCard.tsx
+++ b/src/features/matches/components/MatchCard/MatchCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useGoalQuery } from '@/hooks/useGoalQuery';
 import { Card, CardContent } from '@/components/ui/card';
 import { getMatchDetails } from '../../api';
 import MatchHeader from './MatchHeader';
@@ -10,6 +10,7 @@ import PenaltyShootoutSection from './PenaltyShootoutSection';
 import GoalSection from './GoalSection';
 import TeamLineupsSection from './TeamLineupsSection';
 import MatchFooter from './MatchFooter';
+import { DEFAULT_STALE_TIME } from '@/constants/query';
 
 interface MatchCardProps {
   matchId: number;
@@ -22,10 +23,8 @@ const MatchCard: React.FC<MatchCardProps> = ({ matchId, className = '' }) => {
     data: match,
     isLoading: matchLoading,
     error: matchError,
-  } = useQuery({
-    queryKey: ['match', 'details', matchId],
-    queryFn: () => getMatchDetails(matchId),
-    staleTime: 5 * 60 * 1000, // 5분간 캐시 유지
+  } = useGoalQuery(getMatchDetails, [matchId], {
+    staleTime: DEFAULT_STALE_TIME,
   });
 
   // 로딩 상태 체크

--- a/src/features/matches/components/MatchCard/PenaltyShootoutSection.tsx
+++ b/src/features/matches/components/MatchCard/PenaltyShootoutSection.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import React, { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useGoalQuery } from '@/hooks/useGoalQuery';
 import { MatchWithTeams } from '@/lib/types/database';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { getPenaltyShootoutDetails } from '../../api';
 import { hasPenaltyShootout } from '../../lib/matchUtils';
+import { DEFAULT_STALE_TIME } from '@/constants/query';
 
 interface PenaltyShootoutSectionProps {
   match: MatchWithTeams;
@@ -29,11 +30,9 @@ const PenaltyShootoutSection: React.FC<PenaltyShootoutSectionProps> = ({
     data: penaltyRecords = [],
     isLoading,
     error,
-  } = useQuery({
-    queryKey: ['match', 'penalty', match.match_id],
-    queryFn: () => getPenaltyShootoutDetails(match.match_id),
-    staleTime: 5 * 60 * 1000, // 5분간 캐시 유지
-    enabled: hasPenaltyShootout(match), // 승부차기가 있을 때만 호출
+  } = useGoalQuery(getPenaltyShootoutDetails, [match.match_id], {
+    staleTime: DEFAULT_STALE_TIME,
+    enabled: hasPenaltyShootout(match),
   });
 
   const homeRecords = penaltyRecords.filter(

--- a/src/features/matches/components/MatchCard/TeamLineupsSection.tsx
+++ b/src/features/matches/components/MatchCard/TeamLineupsSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useGoalQuery } from '@/hooks/useGoalQuery';
 import { MatchWithTeams } from '@/lib/types/database';
 import { Badge } from '@/components/ui/badge';
 import { getMatchLineups } from '../../api';
@@ -10,6 +10,7 @@ import {
   getPositionText,
   getPositionOrder,
 } from '../../lib/matchUtils';
+import { DEFAULT_STALE_TIME } from '@/constants/query';
 
 interface TeamLineupsSectionProps {
   match: MatchWithTeams;
@@ -25,10 +26,8 @@ const TeamLineupsSection: React.FC<TeamLineupsSectionProps> = ({
     data: lineups = {},
     isLoading,
     error,
-  } = useQuery({
-    queryKey: ['match', 'lineups', match.match_id],
-    queryFn: () => getMatchLineups(match.match_id),
-    staleTime: 5 * 60 * 1000, // 5분간 캐시 유지
+  } = useGoalQuery(getMatchLineups, [match.match_id], {
+    staleTime: DEFAULT_STALE_TIME,
   });
 
   const homeTeamKey = `${match.match_id}_${match.home_team_id}`;

--- a/src/features/matches/components/PilotSeasonResults.tsx
+++ b/src/features/matches/components/PilotSeasonResults.tsx
@@ -2,10 +2,11 @@
 
 import React from 'react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { useQuery } from '@tanstack/react-query';
+import { useGoalQuery } from '@/hooks/useGoalQuery';
 import { getPilotSeasonMatches } from '../api';
 import MatchCard from './MatchCard/MatchCard';
 import SeasonSummary from './SeasonSummary';
+import { DEFAULT_STALE_TIME } from '@/constants/query';
 
 interface PilotSeasonResultsProps {
   className?: string;
@@ -18,10 +19,8 @@ const PilotSeasonResults: React.FC<PilotSeasonResultsProps> = ({
     data: matches = [],
     isLoading,
     error,
-  } = useQuery({
-    queryKey: ['matches', 'pilot-season'],
-    queryFn: getPilotSeasonMatches,
-    staleTime: 5 * 60 * 1000, // 5분간 캐시 유지
+  } = useGoalQuery(getPilotSeasonMatches, [], {
+    staleTime: DEFAULT_STALE_TIME,
   });
 
   if (isLoading) {

--- a/src/features/matches/components/Season1Results.tsx
+++ b/src/features/matches/components/Season1Results.tsx
@@ -2,11 +2,12 @@
 
 import React from 'react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { useQuery } from '@tanstack/react-query';
+import { useGoalQuery } from '@/hooks/useGoalQuery';
 import { getSeason1Matches } from '../api';
 import { MatchWithTeams } from '@/lib/types/database';
 import MatchCard from './MatchCard/MatchCard';
 import SeasonSummary from './SeasonSummary';
+import { DEFAULT_STALE_TIME } from '@/constants/query';
 
 interface Season1ResultsProps {
   className?: string;
@@ -18,11 +19,7 @@ const Season1Results: React.FC<Season1ResultsProps> = ({ className }) => {
     data: matches = [],
     isLoading: matchesLoading,
     error: matchesError,
-  } = useQuery({
-    queryKey: ['season1', 'matches'],
-    queryFn: getSeason1Matches,
-    staleTime: 5 * 60 * 1000, // 5분간 캐시 유지
-  });
+  } = useGoalQuery(getSeason1Matches, [], { staleTime: DEFAULT_STALE_TIME });
 
   const getMatchGroup = (match: MatchWithTeams) => {
     const description = match.description || '';

--- a/src/features/matches/components/SeasonSummary.tsx
+++ b/src/features/matches/components/SeasonSummary.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import React from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useGoalQuery } from '@/hooks/useGoalQuery';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { getMatchesBySeason } from '../api';
+import { DEFAULT_STALE_TIME } from '@/constants/query';
 
 interface SeasonSummaryProps {
   seasonId: number;
@@ -27,10 +28,8 @@ const SeasonSummary: React.FC<SeasonSummaryProps> = ({
     data: matches = [],
     isLoading,
     error,
-  } = useQuery({
-    queryKey: ['season-summary', seasonId],
-    queryFn: () => getMatchesBySeason(seasonId),
-    staleTime: 5 * 60 * 1000, // 5분간 캐시 유지
+  } = useGoalQuery(getMatchesBySeason, [seasonId], {
+    staleTime: DEFAULT_STALE_TIME,
   });
 
   // 로딩 상태

--- a/src/hooks/useGoalQuery.ts
+++ b/src/hooks/useGoalQuery.ts
@@ -1,0 +1,55 @@
+'use client';
+
+import {
+  useQuery,
+  UseQueryOptions,
+  QueryKey,
+  UseQueryResult,
+  useSuspenseQuery,
+  UseSuspenseQueryOptions,
+  UseSuspenseQueryResult,
+} from '@tanstack/react-query';
+
+/**
+ * 일반 쿼리 훅 (Goal 프로젝트용)
+ */
+export function useGoalQuery<
+  TQueryFn extends (...args: any[]) => Promise<any>,
+  TParams extends Parameters<TQueryFn>,
+  TData = Awaited<ReturnType<TQueryFn>>,
+>(
+  apiFn: TQueryFn,
+  params: TParams,
+  options?: Omit<
+    UseQueryOptions<TData, Error, TData, QueryKey>,
+    'queryKey' | 'queryFn'
+  >
+): UseQueryResult<TData, Error> {
+  return useQuery<TData, Error, TData, QueryKey>({
+    queryKey: [apiFn.name, ...params],
+    queryFn: () => apiFn(...params),
+    ...options,
+  });
+}
+
+/**
+ * Suspense 쿼리 훅 (Goal 프로젝트용)
+ */
+export function useGoalSuspenseQuery<
+  TQueryFn extends (...args: any[]) => Promise<any>,
+  TParams extends Parameters<TQueryFn>,
+  TData = Awaited<ReturnType<TQueryFn>>,
+>(
+  apiFn: TQueryFn,
+  params: TParams,
+  options?: Omit<
+    UseSuspenseQueryOptions<TData, Error, TData, QueryKey>,
+    'queryKey' | 'queryFn'
+  >
+): UseSuspenseQueryResult<TData, Error> {
+  return useSuspenseQuery<TData, Error, TData, QueryKey>({
+    queryKey: [apiFn.name, ...params],
+    queryFn: () => apiFn(...params),
+    ...options,
+  });
+}


### PR DESCRIPTION
## React Query 훅 통합 및 staleTime 상수화

### 주요 변경사항

- **React Query 커스텀 훅 통합**
  - 기존의 모든 `useQuery` 사용 부분을 `useGoalQuery`(및 Suspense용 `useGoalSuspenseQuery`)로 일괄 변경
  - 프로젝트 도메인에 맞는 네이밍으로 코드 일관성 및 가독성 향상

- **staleTime 상수화 및 중복 제거**
  - 각 쿼리 훅에서 반복적으로 사용되던 `staleTime: 5 * 60 * 1000` 값을 `DEFAULT_STALE_TIME` 상수로 추출
  - 모든 쿼리 훅 옵션에서 해당 상수를 사용하도록 변경하여 유지보수성 및 관리 편의성 개선

