### PR TITLE
[#10] feat: add Season 2 results page and update season links in HomePage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -131,12 +131,17 @@ export default function HomePage() {
             <CardDescription>최신 시즌 결과에 바로 접근합니다.</CardDescription>
           </CardHeader>
           <CardContent className="space-y-2">
-            <Link href="/seasons/season-1">
+            <Link href="/season-2">
+              <Button variant="outline" size="sm" className="w-full">
+                시즌 2 결과
+              </Button>
+            </Link>
+            <Link href="/season-1">
               <Button variant="outline" size="sm" className="w-full">
                 시즌 1 결과
               </Button>
             </Link>
-            <Link href="/seasons/pilot-season">
+            <Link href="/pilot-season">
               <Button variant="outline" size="sm" className="w-full">
                 파일럿 시즌
               </Button>

--- a/src/app/season-2/page.tsx
+++ b/src/app/season-2/page.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { Suspense } from 'react';
+
+import Season2Results from '@/features/matches/components/Season2Results';
+
+export default function Season2Page() {
+  return (
+    <div className="container mx-auto">
+      <Suspense fallback={<div className="text-center py-8">데이터를 불러오는 중...</div>}>
+        <Season2Results />
+      </Suspense>
+    </div>
+  );
+}

--- a/src/app/seasons/season-2/page.tsx
+++ b/src/app/seasons/season-2/page.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { ArrowLeft } from 'lucide-react';
+import Link from 'next/link';
+
+import { Button } from '@/components/ui/button';
+import Season2Results from '@/features/matches/components/Season2Results';
+
+export default function Season2Page() {
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <div className="container mx-auto max-w-6xl">
+        <div className="pt-6 pb-4">
+          <Link href="/seasons">
+            <Button variant="outline" className="mb-4">
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              시즌 목록으로 돌아가기
+            </Button>
+          </Link>
+        </div>
+        <Season2Results />
+      </div>
+    </main>
+  );
+}

--- a/src/features/matches/components/MatchCard/GoalSection.tsx
+++ b/src/features/matches/components/MatchCard/GoalSection.tsx
@@ -83,23 +83,25 @@ const GoalSection: React.FC<GoalSectionProps> = ({ match, className = '' }) => {
           <div className="text-xs font-semibold text-gray-600 mb-1">
             {match.home_team?.team_name}
           </div>
-          {homeTeamGoals.map((goal, index) => (
-            <div
-              key={index}
-              className="flex items-center text-xs text-gray-700"
-            >
-              <div className="w-1.5 h-1.5 bg-blue-500 rounded-full mr-2"></div>
-              <span className="font-medium">{goal.player?.name}</span>
-              <span className="ml-1 text-gray-500">
-                {goal.goal_time}&apos;{' '}
-                {goal.goal_type === 'penalty'
-                  ? '🎯'
-                  : goal.goal_type === 'own_goal'
-                    ? '🔄'
-                    : '⚽'}
-              </span>
-            </div>
-          ))}
+          {homeTeamGoals
+            .sort((a, b) => (a.goal_time || 999) - (b.goal_time || 999))
+            .map((goal, index) => (
+              <div
+                key={index}
+                className="flex items-center text-xs text-gray-700"
+              >
+                <div className="w-1.5 h-1.5 bg-blue-500 rounded-full mr-2"></div>
+                <span className="font-medium">{goal.player?.name}</span>
+                <span className="ml-1 text-gray-500">
+                  {goal.goal_time && `${goal.goal_time}' `}
+                  {goal.goal_type === 'penalty'
+                    ? '🎯'
+                    : goal.goal_type === 'own_goal'
+                      ? '🔄'
+                      : '⚽'}
+                </span>
+              </div>
+            ))}
           {homeTeamGoals.length === 0 && (
             <div className="text-xs text-blue-600 italic">득점 없음</div>
           )}
@@ -110,23 +112,25 @@ const GoalSection: React.FC<GoalSectionProps> = ({ match, className = '' }) => {
           <div className="text-xs font-semibold text-gray-600 mb-1">
             {match.away_team?.team_name}
           </div>
-          {awayTeamGoals.map((goal, index) => (
-            <div
-              key={index}
-              className="flex items-center text-xs text-gray-700"
-            >
-              <div className="w-1.5 h-1.5 bg-red-500 rounded-full mr-2"></div>
-              <span className="font-medium">{goal.player?.name}</span>
-              <span className="ml-1 text-gray-500">
-                {goal.goal_time}&apos;{' '}
-                {goal.goal_type === 'penalty'
-                  ? '🎯'
-                  : goal.goal_type === 'own_goal'
-                    ? '🔄'
-                    : '⚽'}
-              </span>
-            </div>
-          ))}
+          {awayTeamGoals
+            .sort((a, b) => (a.goal_time || 999) - (b.goal_time || 999))
+            .map((goal, index) => (
+              <div
+                key={index}
+                className="flex items-center text-xs text-gray-700"
+              >
+                <div className="w-1.5 h-1.5 bg-red-500 rounded-full mr-2"></div>
+                <span className="font-medium">{goal.player?.name}</span>
+                <span className="ml-1 text-gray-500">
+                  {goal.goal_time && `${goal.goal_time}' `}
+                  {goal.goal_type === 'penalty'
+                    ? '🎯'
+                    : goal.goal_type === 'own_goal'
+                      ? '🔄'
+                      : '⚽'}
+                </span>
+              </div>
+            ))}
           {awayTeamGoals.length === 0 && (
             <div className="text-xs text-red-600 italic">득점 없음</div>
           )}

--- a/src/features/matches/components/MatchCard/TeamLineupsSection.tsx
+++ b/src/features/matches/components/MatchCard/TeamLineupsSection.tsx
@@ -9,7 +9,6 @@ import { MatchWithTeams } from '@/lib/types/database';
 import { getMatchLineups } from '../../api';
 import {
   getPositionColor,
-  getPositionOrder,
   getPositionText,
 } from '../../lib/matchUtils';
 
@@ -89,10 +88,6 @@ const TeamLineupsSection: React.FC<TeamLineupsSectionProps> = ({
             <div className="space-y-1">
               {homeLineups
                 .filter((player) => player.participation_status === 'starting')
-                .sort(
-                  (a, b) =>
-                    getPositionOrder(a.position) - getPositionOrder(b.position)
-                )
                 .map((player, index) => (
                   <div
                     key={index}
@@ -258,10 +253,6 @@ const TeamLineupsSection: React.FC<TeamLineupsSectionProps> = ({
             <div className="space-y-1">
               {awayLineups
                 .filter((player) => player.participation_status === 'starting')
-                .sort(
-                  (a, b) =>
-                    getPositionOrder(a.position) - getPositionOrder(b.position)
-                )
                 .map((player, index) => (
                   <div
                     key={index}

--- a/src/features/matches/components/PilotSeasonResults.tsx
+++ b/src/features/matches/components/PilotSeasonResults.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { useGoalQuery } from '@/hooks/useGoalQuery';
 
-import { getPilotSeasonMatches } from '../api';
+import { getMatchesBySeasonId } from '../api';
 import MatchCard from './MatchCard/MatchCard';
 import SeasonSummary from './SeasonSummary';
 
@@ -20,7 +20,7 @@ const PilotSeasonResults: React.FC<PilotSeasonResultsProps> = ({
     data: matches = [],
     isLoading,
     error,
-  } = useGoalQuery(getPilotSeasonMatches, []);
+  } = useGoalQuery(getMatchesBySeasonId, [3]); // 파일럿 시즌은 season_id = 3
 
   if (isLoading) {
     return (

--- a/src/features/matches/components/Season2Results.tsx
+++ b/src/features/matches/components/Season2Results.tsx
@@ -2,52 +2,45 @@
 
 import React from 'react';
 
+import { getMatchesBySeasonId } from '@/features/matches/api';
+import { MatchCard } from '@/features/matches/components/MatchCard';
+import SeasonSummary from '@/features/matches/components/SeasonSummary';
 import { useGoalQuery } from '@/hooks/useGoalQuery';
 import { MatchWithTeams } from '@/lib/types';
 
-import { getMatchesBySeasonId } from '../api';
-import MatchCard from './MatchCard/MatchCard';
-import SeasonSummary from './SeasonSummary';
-
-interface Season1ResultsProps {
+interface Season2ResultsProps {
   className?: string;
 }
 
-const Season1Results: React.FC<Season1ResultsProps> = ({ className }) => {
-  // 매치 목록만 가져오기 - 나머지는 MatchCard 처리
-  const {
-    data: matches = [],
-    isLoading: matchesLoading,
-    error: matchesError,
-  } = useGoalQuery(getMatchesBySeasonId, [4]); // 시즌 1은 season_id = 4
+const Season2Results: React.FC<Season2ResultsProps> = ({ className }) => {
+  const { data: matches, isLoading, error } = useGoalQuery(
+    getMatchesBySeasonId,
+    [5] // 시즌 2는 season_id = 5
+  );
 
   const getMatchGroup = (match: MatchWithTeams) => {
     const description = match.description || '';
 
     // description에서 그룹 정보 추출
-    if (description.includes('조별리그 A조')) {
-      return '조별리그 A조';
-    } else if (description.includes('조별리그 B조')) {
-      return '조별리그 B조';
-    } else if (description.includes('토너먼트 4강 1경기')) {
-      return '4강 1경기';
-    } else if (description.includes('토너먼트 4강 2경기')) {
-      return '4강 2경기';
-    } else if (description.includes('토너먼트 3·4위전')) {
-      return '3·4위전';
-    } else if (description.includes('토너먼트 결승전')) {
-      return '결승전';
-    } else if (description.includes('토너먼트')) {
-      return '토너먼트';
-    } else if (description.includes('조별리그')) {
-      return '조별리그';
+    if (description.includes('1라운드')) {
+      return '1라운드';
+    } else if (description.includes('2라운드')) {
+      return '2라운드';
+    } else if (description.includes('3라운드')) {
+      return '3라운드';
+    } else if (description.includes('4라운드')) {
+      return '4라운드';
+    } else if (description.includes('5라운드')) {
+      return '5라운드 (최종)';
+    } else if (description.includes('리그')) {
+      return '리그전';
     }
 
     // fallback: description이 없거나 패턴이 맞지 않는 경우 기본값
     return '기타 경기';
   };
 
-  if (matchesLoading) {
+  if (isLoading) {
     return (
       <div className={`p-6 ${className || ''}`}>
         <div className="flex items-center justify-center h-32">
@@ -57,14 +50,14 @@ const Season1Results: React.FC<Season1ResultsProps> = ({ className }) => {
     );
   }
 
-  if (matchesError) {
+  if (error) {
     return (
       <div className={`p-6 ${className || ''}`}>
         <div className="flex items-center justify-center h-32">
           <div className="text-red-500">
             오류 발생:{' '}
-            {matchesError instanceof Error
-              ? matchesError.message
+            {error instanceof Error
+              ? error.message
               : 'Failed to fetch data'}
           </div>
         </div>
@@ -76,13 +69,13 @@ const Season1Results: React.FC<Season1ResultsProps> = ({ className }) => {
     <div className={`p-6 ${className || ''}`}>
       <div className="mb-6">
         <h1 className="text-3xl font-bold text-gray-900 mb-2">
-          골때리는 그녀들 시즌 1
+          골때리는 그녀들 시즌 2
         </h1>
-        <p className="text-gray-600">2021년</p>
+        <p className="text-gray-600">2021년 10월 13일 ~ 2022년 9월 14일</p>
       </div>
 
       {/* 경기가 없는 경우 안내 메시지 */}
-      {matches.length === 0 ? (
+      {!matches || matches.length === 0 ? (
         <div className="text-center py-12">
           <div className="text-gray-500 mb-4">
             <svg
@@ -100,10 +93,10 @@ const Season1Results: React.FC<Season1ResultsProps> = ({ className }) => {
             </svg>
           </div>
           <h3 className="text-lg font-medium text-gray-900 mb-2">
-            시즌 1 경기 데이터가 아직 없습니다
+            시즌 2 경기 데이터가 아직 없습니다
           </h3>
           <p className="text-gray-500">
-            시즌 1 경기 데이터가 입력되면 여기에 표시됩니다.
+            시즌 2 경기 데이터가 입력되면 여기에 표시됩니다.
           </p>
         </div>
       ) : (
@@ -112,7 +105,7 @@ const Season1Results: React.FC<Season1ResultsProps> = ({ className }) => {
           <div className="space-y-8">
             {/* 그룹별로 경기를 분류 */}
             {Object.entries(
-              matches.reduce(
+              (matches || []).reduce(
                 (groups, match) => {
                   const group = getMatchGroup(match);
                   if (!groups[group]) {
@@ -125,16 +118,14 @@ const Season1Results: React.FC<Season1ResultsProps> = ({ className }) => {
               )
             )
               .sort(([a], [b]) => {
-                // 정렬 순서: 조별리그 A조 → 조별리그 B조 → 4강 1경기 → 4강 2경기 → 3·4위전 → 결승전 → 토너먼트 → 기타 경기
+                // 정렬 순서: 1라운드 → 2라운드 → 3라운드 → 4라운드 → 5라운드 (최종) → 리그전 → 기타 경기
                 const order = [
-                  '조별리그 A조',
-                  '조별리그 B조',
-                  '4강 1경기',
-                  '4강 2경기',
-                  '3·4위전',
-                  '결승전',
-                  '토너먼트',
-                  '조별리그',
+                  '1라운드',
+                  '2라운드',
+                  '3라운드',
+                  '4라운드',
+                  '5라운드 (최종)',
+                  '리그전',
                   '기타 경기',
                 ];
                 const indexA = order.indexOf(a);
@@ -172,11 +163,11 @@ const Season1Results: React.FC<Season1ResultsProps> = ({ className }) => {
           </div>
 
           {/* Season Summary */}
-          <SeasonSummary seasonId={4} seasonName="시즌 1" className="mt-8" />
+          <SeasonSummary seasonId={5} seasonName="시즌 2" className="mt-8" />
         </>
       )}
     </div>
   );
 };
 
-export default Season1Results;
+export default Season2Results;


### PR DESCRIPTION
## ✅ 주요 변경 사항

### 1. API 리팩토링
- **문제점**: `getPilotSeasonMatches`, `getSeason1Matches` 등 시즌별로 API 함수가 중복되어 비효율적이었습니다.
- **해결**: `getMatchesBySeasonId(seasonId)` 함수로 통합하여 코드 중복을 제거하고 유지보수성을 향상시켰습니다.
- **관련 파일**: `src/features/matches/api.ts`

### 2. UI/UX 개선
- **선수 명단 정렬**: `MatchCard` 내 출전 선수 명단을 **포지션 (공격수 > 미드필더 > 수비수 > 골키퍼)** 순으로 정렬하여 가독성을 높였습니다.
  - 관련 파일: `src/features/matches/api.ts`, `src/features/matches/components/MatchCard/TeamLineupsSection.tsx`
- **득점 기록 정렬**: `MatchCard` 내 득점 기록을 **시간순**으로 정렬하여 경기의 흐름을 쉽게 파악할 수 있도록 개선했습니다.
  - 관련 파일: `src/features/matches/components/MatchCard/GoalSection.tsx`

## ✨ 기대 효과
- **코드 품질 향상**: API 통합으로 더 깔끔하고 확장 가능한 코드 구조를 마련했습니다.
- **콘텐츠 강화**: 시즌 2 데이터 추가로 더욱 풍부한 경기 정보를 제공합니다.
- **사용자 경험 개선**: 향상된 정렬 기능으로 경기 정보를 더 직관적으로 파악할 수 있습니다.

