### PR TITLE
[#12] fix: update goalkeeper references in PenaltyShootoutSection for accurate display

### DIFF
--- a/src/features/matches/components/MatchCard/PenaltyShootoutSection.tsx
+++ b/src/features/matches/components/MatchCard/PenaltyShootoutSection.tsx
@@ -47,6 +47,19 @@ const PenaltyShootoutSection: React.FC<PenaltyShootoutSectionProps> = ({
       record.team?.team_id === match.away_team_id
   );
 
+  // 각 팀의 골키퍼를 명시적으로 찾습니다.
+  // 홈 팀 골키퍼는 어웨이 팀의 슈팅 기록에서 찾을 수 있습니다.
+  const homeTeamGoalkeeper = penaltyRecords.find(
+    (r: PenaltyShootoutDetailWithPlayers) =>
+      r.team?.team_id === match.away_team_id
+  )?.goalkeeper;
+
+  // 어웨이 팀 골키퍼는 홈 팀의 슈팅 기록에서 찾을 수 있습니다.
+  const awayTeamGoalkeeper = penaltyRecords.find(
+    (r: PenaltyShootoutDetailWithPlayers) =>
+      r.team?.team_id === match.home_team_id
+  )?.goalkeeper;
+
   // 성공률 계산
   const getSuccessRate = (records: PenaltyShootoutDetailWithPlayers[]) => {
     const total = records.length;
@@ -182,7 +195,7 @@ const PenaltyShootoutSection: React.FC<PenaltyShootoutSectionProps> = ({
                                 {record.kicker?.name}
                               </span>
                               <span className="text-xs text-gray-500">
-                                vs {record.goalkeeper?.name}
+                                vs {awayTeamGoalkeeper?.name}
                               </span>
                             </div>
                             <div className="flex items-center">
@@ -244,7 +257,7 @@ const PenaltyShootoutSection: React.FC<PenaltyShootoutSectionProps> = ({
                                 {record.kicker?.name}
                               </span>
                               <span className="text-xs text-gray-500">
-                                vs {record.goalkeeper?.name}
+                                vs {homeTeamGoalkeeper?.name}
                               </span>
                             </div>
                             <div className="flex items-center">


### PR DESCRIPTION

## 📌 주요 변경 사항

### 1. 승부차기 UI 로직 수정
-   **파일**: `src/features/matches/components/MatchCard/PenaltyShootoutSection.tsx`
-   **내용**: 승부차기 기록에서 항상 **상대팀 골키퍼**의 이름이 표시되도록 로직을 수정했습니다. 이전에는 자신의 팀 골키퍼가 표시되는 오류가 있었습니다.
