### PR TITLE
[#14] feat: add standings feature with data fetching and display in Season results components

### DIFF
--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,117 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn('w-full caption-bottom text-sm', className)}
+      {...props}
+    />
+  </div>
+));
+Table.displayName = 'Table';
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
+));
+TableHeader.displayName = 'TableHeader';
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn('[&_tr:last-child]:border-0', className)}
+    {...props}
+  />
+));
+TableBody.displayName = 'TableBody';
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn(
+      'border-t bg-muted/50 font-medium [&>tr]:last:border-b-0',
+      className
+    )}
+    {...props}
+  />
+));
+TableFooter.displayName = 'TableFooter';
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      'border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted',
+      className
+    )}
+    {...props}
+  />
+));
+TableRow.displayName = 'TableRow';
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      'h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0',
+      className
+    )}
+    {...props}
+  />
+));
+TableHead.displayName = 'TableHead';
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn('p-4 align-middle [&:has([role=checkbox])]:pr-0', className)}
+    {...props}
+  />
+));
+TableCell.displayName = 'TableCell';
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn('mt-4 text-sm text-muted-foreground', className)}
+    {...props}
+  />
+));
+TableCaption.displayName = 'TableCaption';
+
+export {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+};

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/lib/utils';
 
 const Table = React.forwardRef<
   HTMLTableElement,
-  React.HTMLAttributes<HTMLTableElement>
+  React.ComponentPropsWithoutRef<'table'>
 >(({ className, ...props }, ref) => (
   <div className="relative w-full overflow-auto">
     <table
@@ -18,7 +18,7 @@ Table.displayName = 'Table';
 
 const TableHeader = React.forwardRef<
   HTMLTableSectionElement,
-  React.HTMLAttributes<HTMLTableSectionElement>
+  React.ComponentPropsWithoutRef<'thead'>
 >(({ className, ...props }, ref) => (
   <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
 ));
@@ -26,7 +26,7 @@ TableHeader.displayName = 'TableHeader';
 
 const TableBody = React.forwardRef<
   HTMLTableSectionElement,
-  React.HTMLAttributes<HTMLTableSectionElement>
+  React.ComponentPropsWithoutRef<'tbody'>
 >(({ className, ...props }, ref) => (
   <tbody
     ref={ref}
@@ -38,7 +38,7 @@ TableBody.displayName = 'TableBody';
 
 const TableFooter = React.forwardRef<
   HTMLTableSectionElement,
-  React.HTMLAttributes<HTMLTableSectionElement>
+  React.ComponentPropsWithoutRef<'tfoot'>
 >(({ className, ...props }, ref) => (
   <tfoot
     ref={ref}
@@ -53,7 +53,7 @@ TableFooter.displayName = 'TableFooter';
 
 const TableRow = React.forwardRef<
   HTMLTableRowElement,
-  React.HTMLAttributes<HTMLTableRowElement>
+  React.ComponentPropsWithoutRef<'tr'>
 >(({ className, ...props }, ref) => (
   <tr
     ref={ref}
@@ -68,7 +68,7 @@ TableRow.displayName = 'TableRow';
 
 const TableHead = React.forwardRef<
   HTMLTableCellElement,
-  React.ThHTMLAttributes<HTMLTableCellElement>
+  React.ComponentPropsWithoutRef<'th'>
 >(({ className, ...props }, ref) => (
   <th
     ref={ref}
@@ -83,7 +83,7 @@ TableHead.displayName = 'TableHead';
 
 const TableCell = React.forwardRef<
   HTMLTableCellElement,
-  React.TdHTMLAttributes<HTMLTableCellElement>
+  React.ComponentPropsWithoutRef<'td'>
 >(({ className, ...props }, ref) => (
   <td
     ref={ref}
@@ -95,7 +95,7 @@ TableCell.displayName = 'TableCell';
 
 const TableCaption = React.forwardRef<
   HTMLTableCaptionElement,
-  React.HTMLAttributes<HTMLTableCaptionElement>
+  React.ComponentPropsWithoutRef<'caption'>
 >(({ className, ...props }, ref) => (
   <caption
     ref={ref}

--- a/src/features/matches/components/PilotSeasonResults.tsx
+++ b/src/features/matches/components/PilotSeasonResults.tsx
@@ -3,6 +3,8 @@
 import React from 'react';
 
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import { getStandingsWithTeam } from '@/features/stats/api';
+import StandingsTable from '@/features/stats/components/StandingsTable';
 import { useGoalQuery } from '@/hooks/useGoalQuery';
 
 import { getMatchesBySeasonId } from '../api';
@@ -21,6 +23,13 @@ const PilotSeasonResults: React.FC<PilotSeasonResultsProps> = ({
     isLoading,
     error,
   } = useGoalQuery(getMatchesBySeasonId, [3]); // 파일럿 시즌은 season_id = 3
+
+  // standings 데이터 fetch
+  const {
+    data: standings = [],
+    isLoading: standingsLoading,
+    error: standingsError,
+  } = useGoalQuery(getStandingsWithTeam, [3]);
 
   if (isLoading) {
     return (
@@ -108,6 +117,20 @@ const PilotSeasonResults: React.FC<PilotSeasonResultsProps> = ({
       </div>
 
       <SeasonSummary seasonId={3} seasonName="파일럿 시즌" className="mt-8" />
+      {/* standings 테이블 노출 */}
+      <div className="mt-8">
+        {standingsLoading ? (
+          <div className="text-center text-gray-500">
+            순위표를 불러오는 중...
+          </div>
+        ) : standingsError ? (
+          <div className="text-center text-red-500">
+            순위표를 불러오지 못했습니다.
+          </div>
+        ) : (
+          <StandingsTable standings={standings} />
+        )}
+      </div>
     </div>
   );
 };

--- a/src/features/matches/components/PilotSeasonResults.tsx
+++ b/src/features/matches/components/PilotSeasonResults.tsx
@@ -119,17 +119,11 @@ const PilotSeasonResults: React.FC<PilotSeasonResultsProps> = ({
       <SeasonSummary seasonId={3} seasonName="파일럿 시즌" className="mt-8" />
       {/* standings 테이블 노출 */}
       <div className="mt-8">
-        {standingsLoading ? (
-          <div className="text-center text-gray-500">
-            순위표를 불러오는 중...
-          </div>
-        ) : standingsError ? (
-          <div className="text-center text-red-500">
-            순위표를 불러오지 못했습니다.
-          </div>
-        ) : (
-          <StandingsTable standings={standings} />
-        )}
+        <StandingsTable
+          standings={standings}
+          standingsLoading={standingsLoading}
+          standingsError={!!standingsError}
+        />
       </div>
     </div>
   );

--- a/src/features/matches/components/Season1Results.tsx
+++ b/src/features/matches/components/Season1Results.tsx
@@ -2,6 +2,8 @@
 
 import React from 'react';
 
+import { getStandingsWithTeam } from '@/features/stats/api';
+import StandingsTable from '@/features/stats/components/StandingsTable';
 import { useGoalQuery } from '@/hooks/useGoalQuery';
 import { MatchWithTeams } from '@/lib/types';
 
@@ -20,6 +22,13 @@ const Season1Results: React.FC<Season1ResultsProps> = ({ className }) => {
     isLoading: matchesLoading,
     error: matchesError,
   } = useGoalQuery(getMatchesBySeasonId, [4]); // 시즌 1은 season_id = 4
+
+  // standings 데이터 fetch
+  const {
+    data: standings = [],
+    isLoading: standingsLoading,
+    error: standingsError,
+  } = useGoalQuery(getStandingsWithTeam, [4]);
 
   const getMatchGroup = (match: MatchWithTeams) => {
     const description = match.description || '';
@@ -173,6 +182,20 @@ const Season1Results: React.FC<Season1ResultsProps> = ({ className }) => {
 
           {/* Season Summary */}
           <SeasonSummary seasonId={4} seasonName="시즌 1" className="mt-8" />
+          {/* standings 테이블 노출 */}
+          <div className="mt-8">
+            {standingsLoading ? (
+              <div className="text-center text-gray-500">
+                순위표를 불러오는 중...
+              </div>
+            ) : standingsError ? (
+              <div className="text-center text-red-500">
+                순위표를 불러오지 못했습니다.
+              </div>
+            ) : (
+              <StandingsTable standings={standings} />
+            )}
+          </div>
         </>
       )}
     </div>

--- a/src/features/matches/components/Season1Results.tsx
+++ b/src/features/matches/components/Season1Results.tsx
@@ -184,17 +184,11 @@ const Season1Results: React.FC<Season1ResultsProps> = ({ className }) => {
           <SeasonSummary seasonId={4} seasonName="시즌 1" className="mt-8" />
           {/* standings 테이블 노출 */}
           <div className="mt-8">
-            {standingsLoading ? (
-              <div className="text-center text-gray-500">
-                순위표를 불러오는 중...
-              </div>
-            ) : standingsError ? (
-              <div className="text-center text-red-500">
-                순위표를 불러오지 못했습니다.
-              </div>
-            ) : (
-              <StandingsTable standings={standings} />
-            )}
+            <StandingsTable
+              standings={standings}
+              standingsLoading={standingsLoading}
+              standingsError={!!standingsError}
+            />
           </div>
         </>
       )}

--- a/src/features/matches/components/Season2Results.tsx
+++ b/src/features/matches/components/Season2Results.tsx
@@ -5,6 +5,8 @@ import React from 'react';
 import { getMatchesBySeasonId } from '@/features/matches/api';
 import { MatchCard } from '@/features/matches/components/MatchCard';
 import SeasonSummary from '@/features/matches/components/SeasonSummary';
+import { getStandingsWithTeam } from '@/features/stats/api';
+import StandingsTable from '@/features/stats/components/StandingsTable';
 import { useGoalQuery } from '@/hooks/useGoalQuery';
 import { MatchWithTeams } from '@/lib/types';
 
@@ -13,10 +15,21 @@ interface Season2ResultsProps {
 }
 
 const Season2Results: React.FC<Season2ResultsProps> = ({ className }) => {
-  const { data: matches, isLoading, error } = useGoalQuery(
+  const {
+    data: matches,
+    isLoading,
+    error,
+  } = useGoalQuery(
     getMatchesBySeasonId,
     [5] // 시즌 2는 season_id = 5
   );
+
+  // standings 데이터 fetch
+  const {
+    data: standings = [],
+    isLoading: standingsLoading,
+    error: standingsError,
+  } = useGoalQuery(getStandingsWithTeam, [5]);
 
   const getMatchGroup = (match: MatchWithTeams) => {
     const description = match.description || '';
@@ -56,9 +69,7 @@ const Season2Results: React.FC<Season2ResultsProps> = ({ className }) => {
         <div className="flex items-center justify-center h-32">
           <div className="text-red-500">
             오류 발생:{' '}
-            {error instanceof Error
-              ? error.message
-              : 'Failed to fetch data'}
+            {error instanceof Error ? error.message : 'Failed to fetch data'}
           </div>
         </div>
       </div>
@@ -164,6 +175,20 @@ const Season2Results: React.FC<Season2ResultsProps> = ({ className }) => {
 
           {/* Season Summary */}
           <SeasonSummary seasonId={5} seasonName="시즌 2" className="mt-8" />
+          {/* standings 테이블 노출 */}
+          <div className="mt-8">
+            {standingsLoading ? (
+              <div className="text-center text-gray-500">
+                순위표를 불러오는 중...
+              </div>
+            ) : standingsError ? (
+              <div className="text-center text-red-500">
+                순위표를 불러오지 못했습니다.
+              </div>
+            ) : (
+              <StandingsTable standings={standings} />
+            )}
+          </div>
         </>
       )}
     </div>

--- a/src/features/matches/components/Season2Results.tsx
+++ b/src/features/matches/components/Season2Results.tsx
@@ -177,17 +177,11 @@ const Season2Results: React.FC<Season2ResultsProps> = ({ className }) => {
           <SeasonSummary seasonId={5} seasonName="시즌 2" className="mt-8" />
           {/* standings 테이블 노출 */}
           <div className="mt-8">
-            {standingsLoading ? (
-              <div className="text-center text-gray-500">
-                순위표를 불러오는 중...
-              </div>
-            ) : standingsError ? (
-              <div className="text-center text-red-500">
-                순위표를 불러오지 못했습니다.
-              </div>
-            ) : (
-              <StandingsTable standings={standings} />
-            )}
+            <StandingsTable
+              standings={standings}
+              standingsLoading={standingsLoading}
+              standingsError={!!standingsError}
+            />
           </div>
         </>
       )}

--- a/src/features/stats/api.ts
+++ b/src/features/stats/api.ts
@@ -156,3 +156,18 @@ export const getStandings = async (seasonId: number): Promise<Standing[]> => {
 
   return data || [];
 };
+
+// Get standings with team name by season
+export const getStandingsWithTeam = async (seasonId: number) => {
+  const { data, error } = await supabase
+    .from('standings')
+    .select(`*, team:team_id (team_id, team_name)`)
+    .eq('season_id', seasonId)
+    .order('position', { ascending: true });
+
+  if (error) {
+    throw new Error(`Failed to fetch standings with team: ${error.message}`);
+  }
+
+  return data || [];
+};

--- a/src/features/stats/components/StandingsTable.tsx
+++ b/src/features/stats/components/StandingsTable.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { FC } from 'react';
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+interface StandingsTableProps {
+  standings: Array<{
+    position: number;
+    team: { team_id: number; team_name: string };
+    matches_played: number;
+    wins: number;
+    draws: number;
+    losses: number;
+    goals_for: number;
+    goals_against: number;
+    goal_difference: number;
+    points: number;
+  }>;
+  className?: string;
+}
+
+function getRankEmoji(position: number) {
+  switch (position) {
+    case 1:
+      return '🥇 1';
+    case 2:
+      return '🥈 2';
+    case 3:
+      return '🥉 3';
+    default:
+      return position;
+  }
+}
+
+const StandingsTable: FC<StandingsTableProps> = ({ standings, className }) => {
+  if (!standings || standings.length === 0) {
+    return (
+      <div className="text-center text-gray-500 py-8">
+        순위표 데이터가 없습니다.
+      </div>
+    );
+  }
+  return (
+    <div className={className}>
+      <h3 className="text-lg font-bold mb-2">순위표</h3>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>순위</TableHead>
+            <TableHead>팀명</TableHead>
+            <TableHead>경기</TableHead>
+            <TableHead>승</TableHead>
+            <TableHead>패</TableHead>
+            <TableHead>득점</TableHead>
+            <TableHead>실점</TableHead>
+            <TableHead>득실차</TableHead>
+            <TableHead>승점</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {standings.map((row) => (
+            <TableRow key={row.team.team_id}>
+              <TableCell>{getRankEmoji(row.position)}</TableCell>
+              <TableCell>{row.team.team_name}</TableCell>
+              <TableCell>{row.matches_played}</TableCell>
+              <TableCell>{row.wins}</TableCell>
+              <TableCell>{row.losses}</TableCell>
+              <TableCell>{row.goals_for}</TableCell>
+              <TableCell>{row.goals_against}</TableCell>
+              <TableCell>{row.goal_difference}</TableCell>
+              <TableCell>{row.points}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+};
+
+export default StandingsTable;

--- a/src/features/stats/components/StandingsTable.tsx
+++ b/src/features/stats/components/StandingsTable.tsx
@@ -25,6 +25,8 @@ interface StandingsTableProps {
     points: number;
   }>;
   className?: string;
+  standingsLoading?: boolean;
+  standingsError?: boolean;
 }
 
 function getRankEmoji(position: number) {
@@ -39,7 +41,32 @@ function getRankEmoji(position: number) {
   }
 }
 
-const StandingsTable: FC<StandingsTableProps> = ({ standings, className }) => {
+const StandingsTable: FC<StandingsTableProps> = ({
+  standings,
+  className,
+  standingsLoading,
+  standingsError,
+}) => {
+  if (standingsLoading) {
+    return (
+      <div className={className}>
+        <h3 className="text-lg font-bold mb-2">순위표</h3>
+        <div className="text-center text-gray-500 py-8">
+          순위표를 불러오는 중...
+        </div>
+      </div>
+    );
+  }
+  if (standingsError) {
+    return (
+      <div className={className}>
+        <h3 className="text-lg font-bold mb-2">순위표</h3>
+        <div className="text-center text-red-500 py-8">
+          순위표를 불러오지 못했습니다.
+        </div>
+      </div>
+    );
+  }
   return (
     <div className={className}>
       <h3 className="text-lg font-bold mb-2">순위표</h3>

--- a/src/features/stats/components/StandingsTable.tsx
+++ b/src/features/stats/components/StandingsTable.tsx
@@ -28,26 +28,18 @@ interface StandingsTableProps {
 }
 
 function getRankEmoji(position: number) {
-  switch (position) {
-    case 1:
-      return '🥇 1';
-    case 2:
-      return '🥈 2';
-    case 3:
-      return '🥉 3';
-    default:
-      return position;
+  if (position === 1) {
+    return '🥇 1';
+  } else if (position === 2) {
+    return '🥈 2';
+  } else if (position === 3) {
+    return '🥉 3';
+  } else {
+    return position;
   }
 }
 
 const StandingsTable: FC<StandingsTableProps> = ({ standings, className }) => {
-  if (!standings || standings.length === 0) {
-    return (
-      <div className="text-center text-gray-500 py-8">
-        순위표 데이터가 없습니다.
-      </div>
-    );
-  }
   return (
     <div className={className}>
       <h3 className="text-lg font-bold mb-2">순위표</h3>
@@ -66,19 +58,27 @@ const StandingsTable: FC<StandingsTableProps> = ({ standings, className }) => {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {standings.map((row) => (
-            <TableRow key={row.team.team_id}>
-              <TableCell>{getRankEmoji(row.position)}</TableCell>
-              <TableCell>{row.team.team_name}</TableCell>
-              <TableCell>{row.matches_played}</TableCell>
-              <TableCell>{row.wins}</TableCell>
-              <TableCell>{row.losses}</TableCell>
-              <TableCell>{row.goals_for}</TableCell>
-              <TableCell>{row.goals_against}</TableCell>
-              <TableCell>{row.goal_difference}</TableCell>
-              <TableCell>{row.points}</TableCell>
+          {standings.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={9} className="text-center text-gray-500 py-8">
+                순위표 데이터가 없습니다.
+              </TableCell>
             </TableRow>
-          ))}
+          ) : (
+            standings.map((row) => (
+              <TableRow key={row.team.team_id}>
+                <TableCell>{getRankEmoji(row.position)}</TableCell>
+                <TableCell>{row.team.team_name}</TableCell>
+                <TableCell>{row.matches_played}</TableCell>
+                <TableCell>{row.wins}</TableCell>
+                <TableCell>{row.losses}</TableCell>
+                <TableCell>{row.goals_for}</TableCell>
+                <TableCell>{row.goals_against}</TableCell>
+                <TableCell>{row.goal_difference}</TableCell>
+                <TableCell>{row.points}</TableCell>
+              </TableRow>
+            ))
+          )}
         </TableBody>
       </Table>
     </div>


### PR DESCRIPTION
### 주요 변경사항

#### 1. standings 테이블 UI 개선
- standings 테이블에서 '무' 컬럼(무승부) 완전 제거
- 1~3위 순위 앞에 각각 🥇, 🥈, 🥉 이모지 노출
- 이모지 변환 로직을 getRankEmoji 함수로 분리하여 코드 가독성 향상

#### 2. 코드 리팩토링
- StandingsTable 컴포넌트에서 React.FC → FC로 변경
- getRankEmoji 함수 분리 및 적용

---

### 적용 화면
- 시즌1, 시즌2, 파일럿 시즌 결과 페이지에서 순위표가 실제 리그 규칙에 맞게 노출됨
- 1~3위는 메달 이모지, 4위 이하부터는 숫자만 표시
